### PR TITLE
feat: weekdays and beacon slots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 coverage
 coverage.json
 typechain
+.DS_Store
 
 # Hardhat files
 cache

--- a/src/utils/BeaconNetworks.sol
+++ b/src/utils/BeaconNetworks.sol
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import {BeaconSlotLib} from "./BeaconSlotLib.sol";
+
+/// @notice Helper contract providing easy access to beacon chain calculations for specific networks.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/BeaconNetworks.sol)
+/// @dev
+/// This contract provides convenience functions for common networks, eliminating the need
+/// to pass genesis times manually. Inherit from this contract to get easy access to
+/// beacon chain timing for all supported networks.
+abstract contract BeaconNetworks {
+    using BeaconSlotLib for uint256;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    MAINNET FUNCTIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current slot on Ethereum mainnet.
+    function getMainnetSlot() internal view returns (uint256) {
+        return BeaconSlotLib.getCurrentSlot(BeaconSlotLib.MAINNET_GENESIS);
+    }
+
+    /// @dev Returns the current epoch on Ethereum mainnet.
+    function getMainnetEpoch() internal view returns (uint256) {
+        return BeaconSlotLib.slotToEpoch(getMainnetSlot());
+    }
+
+    /// @dev Returns detailed information about the current mainnet slot.
+    function getMainnetSlotInfo() internal view returns (BeaconSlotLib.SlotInfo memory) {
+        return BeaconSlotLib.getSlotInfo(getMainnetSlot(), BeaconSlotLib.MAINNET_GENESIS);
+    }
+
+    /// @dev Checks if we're within the attestation window on mainnet.
+    function isMainnetAttestationWindow() internal view returns (bool) {
+        return BeaconSlotLib.isInAttestationWindow(getMainnetSlot(), BeaconSlotLib.MAINNET_GENESIS);
+    }
+
+    /// @dev Returns the mainnet slot at a specific timestamp.
+    function getMainnetSlotAtTime(uint256 timestamp) internal pure returns (uint256) {
+        return BeaconSlotLib.getSlotAtTime(timestamp, BeaconSlotLib.MAINNET_GENESIS);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    SEPOLIA FUNCTIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current slot on Sepolia testnet.
+    function getSepoliaSlot() internal view returns (uint256) {
+        return BeaconSlotLib.getCurrentSlot(BeaconSlotLib.SEPOLIA_GENESIS);
+    }
+
+    /// @dev Returns the current epoch on Sepolia testnet.
+    function getSepoliaEpoch() internal view returns (uint256) {
+        return BeaconSlotLib.slotToEpoch(getSepoliaSlot());
+    }
+
+    /// @dev Returns detailed information about the current Sepolia slot.
+    function getSepoliaSlotInfo() internal view returns (BeaconSlotLib.SlotInfo memory) {
+        return BeaconSlotLib.getSlotInfo(getSepoliaSlot(), BeaconSlotLib.SEPOLIA_GENESIS);
+    }
+
+    /// @dev Returns the Sepolia slot at a specific timestamp.
+    function getSepoliaSlotAtTime(uint256 timestamp) internal pure returns (uint256) {
+        return BeaconSlotLib.getSlotAtTime(timestamp, BeaconSlotLib.SEPOLIA_GENESIS);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    HOLESKY FUNCTIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current slot on Holesky testnet.
+    function getHoleskySlot() internal view returns (uint256) {
+        return BeaconSlotLib.getCurrentSlot(BeaconSlotLib.HOLESKY_GENESIS);
+    }
+
+    /// @dev Returns the current epoch on Holesky testnet.
+    function getHoleskyEpoch() internal view returns (uint256) {
+        return BeaconSlotLib.slotToEpoch(getHoleskySlot());
+    }
+
+    /// @dev Returns detailed information about the current Holesky slot.
+    function getHoleskySlotInfo() internal view returns (BeaconSlotLib.SlotInfo memory) {
+        return BeaconSlotLib.getSlotInfo(getHoleskySlot(), BeaconSlotLib.HOLESKY_GENESIS);
+    }
+
+    /// @dev Returns the Holesky slot at a specific timestamp.
+    function getHoleskySlotAtTime(uint256 timestamp) internal pure returns (uint256) {
+        return BeaconSlotLib.getSlotAtTime(timestamp, BeaconSlotLib.HOLESKY_GENESIS);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   CROSS-NETWORK UTILITIES                 */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Enum for supported networks.
+    enum Network {
+        MAINNET,
+        SEPOLIA,
+        HOLESKY
+    }
+
+    /// @dev Returns the genesis time for a specific network.
+    function getGenesisTime(Network network) internal pure returns (uint256) {
+        if (network == Network.MAINNET) return BeaconSlotLib.MAINNET_GENESIS;
+        if (network == Network.SEPOLIA) return BeaconSlotLib.SEPOLIA_GENESIS;
+        if (network == Network.HOLESKY) return BeaconSlotLib.HOLESKY_GENESIS;
+        revert("Unsupported network");
+    }
+
+    /// @dev Returns the current slot for any supported network.
+    function getCurrentSlotForNetwork(Network network) internal view returns (uint256) {
+        return BeaconSlotLib.getCurrentSlot(getGenesisTime(network));
+    }
+
+    /// @dev Returns slot information for any supported network.
+    function getSlotInfoForNetwork(uint256 slot, Network network) 
+        internal 
+        view 
+        returns (BeaconSlotLib.SlotInfo memory) 
+    {
+        return BeaconSlotLib.getSlotInfo(slot, getGenesisTime(network));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    UTILITY FUNCTIONS                      */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns true if any of the supported networks are currently in attestation window.
+    function isAnyNetworkInAttestationWindow() internal view returns (bool) {
+        return isMainnetAttestationWindow() ||
+               BeaconSlotLib.isInAttestationWindow(getSepoliaSlot(), BeaconSlotLib.SEPOLIA_GENESIS) ||
+               BeaconSlotLib.isInAttestationWindow(getHoleskySlot(), BeaconSlotLib.HOLESKY_GENESIS);
+    }
+
+    /// @dev Returns the slot difference between mainnet and a testnet.
+    /// @param testnetSlot The testnet slot to compare.
+    /// @param network The testnet network.
+    /// @return difference The absolute difference in slots (always positive).
+    function getSlotDifference(uint256 testnetSlot, Network network) 
+        internal 
+        view 
+        returns (uint256 difference) 
+    {
+        uint256 mainnetSlot = getMainnetSlot();
+        
+        // Convert both slots to the same time basis for comparison
+        uint256 mainnetTime = BeaconSlotLib.getSlotStartTime(mainnetSlot, BeaconSlotLib.MAINNET_GENESIS);
+        uint256 testnetTime = BeaconSlotLib.getSlotStartTime(testnetSlot, getGenesisTime(network));
+        
+        difference = mainnetTime > testnetTime ? 
+            (mainnetTime - testnetTime) / BeaconSlotLib.SECONDS_PER_SLOT :
+            (testnetTime - mainnetTime) / BeaconSlotLib.SECONDS_PER_SLOT;
+    }
+}

--- a/src/utils/BeaconSlotLib.sol
+++ b/src/utils/BeaconSlotLib.sol
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/// @notice Library for Ethereum beacon chain slot calculations.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/BeaconSlotLib.sol)
+/// @dev
+/// This library provides gas-optimized functions for calculating Ethereum beacon chain
+/// slot numbers, epochs, and timing information. All functions are pure or view and
+/// designed to work with any beacon chain network by accepting genesis time as a parameter.
+library BeaconSlotLib {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Seconds per slot in the beacon chain.
+    uint256 internal constant SECONDS_PER_SLOT = 12;
+
+    /// @dev Number of slots per epoch.
+    uint256 internal constant SLOTS_PER_EPOCH = 32;
+
+    /// @dev Seconds per epoch (12 * 32).
+    uint256 internal constant SECONDS_PER_EPOCH = 384;
+
+    /// @dev Attestation deadline within a slot (4 seconds).
+    uint256 internal constant ATTESTATION_DEADLINE = 4;
+
+    // Network genesis times (Unix timestamps)
+
+    /// @dev Mainnet genesis time: December 1, 2020, 12:00:23 PM UTC.
+    uint256 internal constant MAINNET_GENESIS = 1606824023;
+
+    /// @dev Goerli testnet genesis time: March 23, 2021, 2:00:00 PM UTC.
+    uint256 internal constant GOERLI_GENESIS = 1616508000;
+
+    /// @dev Sepolia testnet genesis time: June 20, 2022, 2:00:00 PM UTC.
+    uint256 internal constant SEPOLIA_GENESIS = 1655733600;
+
+    /// @dev Holesky testnet genesis time: September 28, 2023, 12:00:00 PM UTC.
+    uint256 internal constant HOLESKY_GENESIS = 1695902400;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          ERRORS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The slot number is invalid.
+    error InvalidSlot();
+
+    /// @dev The epoch number is invalid.
+    error InvalidEpoch();
+
+    /// @dev The genesis time is invalid.
+    error InvalidGenesisTime();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         STRUCTS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Comprehensive information about a beacon chain slot.
+    struct SlotInfo {
+        uint256 slot;
+        uint256 epoch;
+        uint256 slotInEpoch;
+        uint256 startTime;
+        uint256 endTime;
+        bool isActive;
+        bool inAttestationWindow;
+    }
+
+    /// @dev Information about a beacon chain epoch.
+    struct EpochInfo {
+        uint256 epoch;
+        uint256 firstSlot;
+        uint256 lastSlot;
+        uint256 startTime;
+        uint256 endTime;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     CORE CALCULATIONS                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current beacon chain slot based on block timestamp.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return slot The current slot number, or 0 if before genesis.
+    function getCurrentSlot(uint256 genesisTime) internal view returns (uint256 slot) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let ts := timestamp()
+            let isAfterGenesis := gt(ts, genesisTime)
+            let secondsSince := mul(isAfterGenesis, sub(ts, genesisTime))
+            slot := div(secondsSince, SECONDS_PER_SLOT)
+        }
+    }
+
+    /// @dev Returns the slot number at a specific timestamp.
+    /// @param queryTime The timestamp to query.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return slot The slot number at the given timestamp, or 0 if before genesis.
+    function getSlotAtTime(uint256 queryTime, uint256 genesisTime) internal pure returns (uint256 slot) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let isAfterGenesis := gt(queryTime, genesisTime)
+            let secondsSince := mul(isAfterGenesis, sub(queryTime, genesisTime))
+            slot := div(secondsSince, SECONDS_PER_SLOT)
+        }
+    }
+
+    /// @dev Returns the start timestamp of a given slot.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return startTime The timestamp when the slot starts.
+    function getSlotStartTime(uint256 slot, uint256 genesisTime) internal pure returns (uint256 startTime) {
+        unchecked {
+            startTime = genesisTime + (slot * SECONDS_PER_SLOT);
+        }
+    }
+
+    /// @dev Returns the end timestamp of a given slot.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return endTime The timestamp when the slot ends.
+    function getSlotEndTime(uint256 slot, uint256 genesisTime) internal pure returns (uint256 endTime) {
+        unchecked {
+            endTime = genesisTime + ((slot + 1) * SECONDS_PER_SLOT);
+        }
+    }
+
+    /// @dev Converts a slot number to its epoch number.
+    /// @param slot The slot number.
+    /// @return epoch The epoch number containing the slot.
+    function slotToEpoch(uint256 slot) internal pure returns (uint256 epoch) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Use bit shifting since SLOTS_PER_EPOCH = 32 = 2^5
+            epoch := shr(5, slot)
+        }
+    }
+
+    /// @dev Returns the position of a slot within its epoch (0-31).
+    /// @param slot The slot number.
+    /// @return slotInEpoch The position within the epoch.
+    function getSlotInEpoch(uint256 slot) internal pure returns (uint256 slotInEpoch) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Use bitwise AND since SLOTS_PER_EPOCH = 32, mask = 31
+            slotInEpoch := and(slot, 31)
+        }
+    }
+
+    /// @dev Returns the first slot number of a given epoch.
+    /// @param epoch The epoch number.
+    /// @return firstSlot The first slot number in the epoch.
+    function epochToFirstSlot(uint256 epoch) internal pure returns (uint256 firstSlot) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Use bit shifting since SLOTS_PER_EPOCH = 32 = 2^5
+            firstSlot := shl(5, epoch)
+        }
+    }
+
+    /// @dev Returns the last slot number of a given epoch.
+    /// @param epoch The epoch number.
+    /// @return lastSlot The last slot number in the epoch.
+    function epochToLastSlot(uint256 epoch) internal pure returns (uint256 lastSlot) {
+        unchecked {
+            lastSlot = epochToFirstSlot(epoch) + SLOTS_PER_EPOCH - 1;
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    TIMING CALCULATIONS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the time until a slot starts (negative if already started).
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return secondsUntil Seconds until slot starts (negative if in the past).
+    function getTimeUntilSlot(uint256 slot, uint256 genesisTime) internal view returns (int256 secondsUntil) {
+        uint256 slotStartTime = getSlotStartTime(slot, genesisTime);
+        unchecked {
+            secondsUntil = int256(slotStartTime) - int256(block.timestamp);
+        }
+    }
+
+    /// @dev Checks if a slot is currently active.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return active True if the slot is currently active.
+    function isSlotActive(uint256 slot, uint256 genesisTime) internal view returns (bool active) {
+        uint256 startTime = getSlotStartTime(slot, genesisTime);
+        uint256 endTime = getSlotEndTime(slot, genesisTime);
+        active = block.timestamp >= startTime && block.timestamp < endTime;
+    }
+
+    /// @dev Checks if we're within the attestation window for a slot (0-4 seconds).
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return inWindow True if within the attestation window.
+    function isInAttestationWindow(uint256 slot, uint256 genesisTime) internal view returns (bool inWindow) {
+        uint256 startTime = getSlotStartTime(slot, genesisTime);
+        uint256 timeSinceStart = block.timestamp >= startTime ? block.timestamp - startTime : 0;
+        inWindow = timeSinceStart <= ATTESTATION_DEADLINE;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   INFORMATION QUERIES                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns comprehensive information about a slot.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return info Detailed information about the slot.
+    function getSlotInfo(uint256 slot, uint256 genesisTime) internal view returns (SlotInfo memory info) {
+        info.slot = slot;
+        info.epoch = slotToEpoch(slot);
+        info.slotInEpoch = getSlotInEpoch(slot);
+        info.startTime = getSlotStartTime(slot, genesisTime);
+        info.endTime = getSlotEndTime(slot, genesisTime);
+        info.isActive = isSlotActive(slot, genesisTime);
+        info.inAttestationWindow = info.isActive && isInAttestationWindow(slot, genesisTime);
+    }
+
+    /// @dev Returns information about an epoch.
+    /// @param epoch The epoch number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return info Detailed information about the epoch.
+    function getEpochInfo(uint256 epoch, uint256 genesisTime) internal pure returns (EpochInfo memory info) {
+        info.epoch = epoch;
+        info.firstSlot = epochToFirstSlot(epoch);
+        info.lastSlot = epochToLastSlot(epoch);
+        info.startTime = getSlotStartTime(info.firstSlot, genesisTime);
+        info.endTime = getSlotEndTime(info.lastSlot, genesisTime);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    BATCH OPERATIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the range of slots that occur within a time period.
+    /// @param startTime The start timestamp.
+    /// @param endTime The end timestamp.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return startSlot The first slot in the range.
+    /// @return endSlot The last slot in the range.
+    /// @return count The number of slots in the range.
+    function getSlotsInTimeRange(uint256 startTime, uint256 endTime, uint256 genesisTime)
+        internal
+        pure
+        returns (uint256 startSlot, uint256 endSlot, uint256 count)
+    {
+        if (startTime > endTime) {
+            return (0, 0, 0);
+        }
+        
+        startSlot = getSlotAtTime(startTime, genesisTime);
+        endSlot = getSlotAtTime(endTime, genesisTime);
+        
+        // Handle case where endTime is exactly at slot boundary
+        if (endTime == getSlotStartTime(endSlot, genesisTime) && endSlot > 0) {
+            endSlot -= 1;
+        }
+        
+        count = endSlot >= startSlot ? endSlot - startSlot + 1 : 0;
+    }
+
+    /// @dev Returns the first and last slot numbers for an epoch.
+    /// @param epoch The epoch number.
+    /// @return firstSlot The first slot in the epoch.
+    /// @return lastSlot The last slot in the epoch.
+    function getEpochBounds(uint256 epoch) internal pure returns (uint256 firstSlot, uint256 lastSlot) {
+        firstSlot = epochToFirstSlot(epoch);
+        lastSlot = epochToLastSlot(epoch);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   NETWORK UTILITIES                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current slot for Ethereum mainnet.
+    /// @return slot The current mainnet slot.
+    function getCurrentMainnetSlot() internal view returns (uint256 slot) {
+        slot = getCurrentSlot(MAINNET_GENESIS);
+    }
+
+    /// @dev Returns the current slot for Sepolia testnet.
+    /// @return slot The current Sepolia slot.
+    function getCurrentSepoliaSlot() internal view returns (uint256 slot) {
+        slot = getCurrentSlot(SEPOLIA_GENESIS);
+    }
+
+    /// @dev Returns the current slot for Holesky testnet.
+    /// @return slot The current Holesky slot.
+    function getCurrentHoleskySlot() internal view returns (uint256 slot) {
+        slot = getCurrentSlot(HOLESKY_GENESIS);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    HELPER FUNCTIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Formats a slot number with epoch information.
+    /// @param slot The slot number.
+    /// @return formatted A string representation of the slot and epoch.
+    /// @dev Note: This function is provided for convenience but may be gas-expensive.
+    /// Consider using LibString.toString() directly if you need just the number.
+    function formatSlot(uint256 slot) internal pure returns (string memory formatted) {
+        // For production use, import LibString and use LibString.toString()
+        // This is a simplified implementation for demonstration
+        uint256 epoch = slotToEpoch(slot);
+        uint256 slotInEpoch = getSlotInEpoch(slot);
+        
+        formatted = string(abi.encodePacked(
+            "Slot ", _toString(slot),
+            " (Epoch ", _toString(epoch),
+            ", Slot ", _toString(slotInEpoch), "/31)"
+        ));
+    }
+
+    /// @dev Simple internal toString function.
+    /// @dev For production, use LibString.toString() instead.
+    function _toString(uint256 value) private pure returns (string memory str) {
+        if (value == 0) return "0";
+        
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        
+        str = string(buffer);
+    }
+}

--- a/src/utils/DateTimeLib.sol
+++ b/src/utils/DateTimeLib.sol
@@ -372,6 +372,28 @@ library DateTimeLib {
         }
     }
 
+    /// @dev Returns the unix timestamp of the given `n`th weekday `wd0`, in `month` of `year`.
+    /// If the nth occurrence doesn't exist, returns the last occurrence of that weekday.
+    /// This follows the C++ date library pattern for handling overflow.
+    /// Example: 5th Friday of November 2020 returns 4th Friday (the last one).
+    function nthWeekdayInMonthOfYearTimestamp0Safe(uint256 year, uint256 month, uint256 n, uint256 wd0)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        // First try to get the requested nth weekday
+        result = nthWeekdayInMonthOfYearTimestamp0(year, month, n, wd0);
+        
+        // If it doesn't exist (returns 0), find the last occurrence
+        if (result == 0 && n > 0) {
+            // Try n-1, n-2, etc. until we find a valid one
+            for (uint256 i = n - 1; i > 0; i--) {
+                result = nthWeekdayInMonthOfYearTimestamp0(year, month, i, wd0);
+                if (result != 0) break;
+            }
+        }
+    }
+
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*              DATE TIME ARITHMETIC OPERATIONS               */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/

--- a/src/utils/DateTimeLib.sol
+++ b/src/utils/DateTimeLib.sol
@@ -32,6 +32,16 @@ library DateTimeLib {
     uint256 internal constant SAT = 6;
     uint256 internal constant SUN = 7;
 
+    // Weekdays are 0-indexed, following C convention (Sunday as start of week).
+
+    uint256 internal constant SUN_0 = 0;
+    uint256 internal constant MON_0 = 1;
+    uint256 internal constant TUE_0 = 2;
+    uint256 internal constant WED_0 = 3;
+    uint256 internal constant THU_0 = 4;
+    uint256 internal constant FRI_0 = 5;
+    uint256 internal constant SAT_0 = 6;
+
     // Months and days of months are 1-indexed, adhering to ISO 8601.
 
     uint256 internal constant JAN = 1;
@@ -194,6 +204,16 @@ library DateTimeLib {
         }
     }
 
+    /// @dev Returns the weekday from the unix timestamp (0-indexed).
+    /// Sunday: 0, Monday: 1, Tuesday: 2, ....., Saturday: 6.
+    /// This follows the C convention where Sunday is the start of the week.
+    function weekday0(uint256 timestamp) internal pure returns (uint256 result) {
+        unchecked {
+            // Jan 1, 1970 was Thursday (4 in 0-indexed where Sunday=0)
+            result = (timestamp / 86400 + 4) % 7;
+        }
+    }
+
     /// @dev Returns if (`year`,`month`,`day`) is a supported date.
     /// - `1970 <= year <= MAX_SUPPORTED_YEAR`.
     /// - `1 <= month <= 12`.
@@ -270,6 +290,32 @@ library DateTimeLib {
         }
     }
 
+    /// @dev Returns the unix timestamp of the given `n`th weekday `wd0`, in `month` of `year` (0-indexed).
+    /// Example: 3rd Friday of Feb 2022 is `nthWeekdayInMonthOfYearTimestamp0(2022, 2, 3, 5)`
+    /// Note: `n` is 1-indexed, but `wd0` is 0-indexed (Sunday = 0, Monday = 1, ..., Saturday = 6).
+    /// Invalid weekdays (i.e. `wd0 > 6`) result in undefined behavior.
+    function nthWeekdayInMonthOfYearTimestamp0(uint256 year, uint256 month, uint256 n, uint256 wd0)
+        internal
+        pure
+        returns (uint256 result)
+    {
+        uint256 d = dateToEpochDay(year, month, 1);
+        uint256 md = daysInMonth(year, month);
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Get weekday of first day of month (0-indexed)
+            let firstDayWd0 := mod(add(d, 4), 7)
+            // Calculate days to add to get to first occurrence of target weekday
+            let diff := sub(wd0, firstDayWd0)
+            // If diff is negative, add 7 to get positive offset
+            diff := add(diff, mul(7, slt(diff, 0)))
+            // Calculate the date for nth occurrence (1-indexed day of month)
+            let date := add(1, add(mul(sub(n, 1), 7), diff))
+            // Return timestamp if date is valid, 0 otherwise
+            result := mul(mul(86400, add(sub(date, 1), d)), and(lt(date, add(md, 1)), iszero(iszero(n))))
+        }
+    }
+
     /// @dev Returns the unix timestamp of the most recent Monday.
     function mondayTimestamp(uint256 timestamp) internal pure returns (uint256 result) {
         uint256 t = timestamp;
@@ -280,10 +326,50 @@ library DateTimeLib {
         }
     }
 
+    /// @dev Returns the unix timestamp of the most recent Monday (0-indexed).
+    /// Uses 0-indexed weekday where Sunday = 0, Monday = 1.
+    function mondayTimestamp0(uint256 timestamp) internal pure returns (uint256 result) {
+        unchecked {
+            uint256 day = timestamp / 86400;
+            uint256 wd0 = weekday0(timestamp);
+            // If Sunday (0), go back 6 days; if Monday (1), stay; otherwise go back (wd0 - 1) days
+            uint256 daysBack = wd0 == 0 ? 6 : wd0 - 1;
+            // Handle edge case for the first week of Unix time
+            if (day < daysBack) {
+                result = 0;
+            } else {
+                result = (day - daysBack) * 86400;
+            }
+        }
+    }
+
     /// @dev Returns whether the unix timestamp falls on a Saturday or Sunday.
     /// To check whether it is a week day, just take the negation of the result.
     function isWeekEnd(uint256 timestamp) internal pure returns (bool result) {
         result = weekday(timestamp) > FRI;
+    }
+
+    /// @dev Returns whether the unix timestamp falls on a Saturday or Sunday (0-indexed).
+    /// To check whether it is a week day, just take the negation of the result.
+    function isWeekEnd0(uint256 timestamp) internal pure returns (bool result) {
+        uint256 wd = weekday0(timestamp);
+        result = wd == SUN_0 || wd == SAT_0;
+    }
+
+    /// @dev Converts a 1-indexed weekday (1-7) to 0-indexed (0-6).
+    /// Monday (1) -> Monday (1), ..., Saturday (6) -> Saturday (6), Sunday (7) -> Sunday (0).
+    function weekdayTo0Indexed(uint256 weekday1) internal pure returns (uint256 result) {
+        unchecked {
+            result = weekday1 == 7 ? 0 : weekday1;
+        }
+    }
+
+    /// @dev Converts a 0-indexed weekday (0-6) to 1-indexed (1-7).
+    /// Sunday (0) -> Sunday (7), Monday (1) -> Monday (1), ..., Saturday (6) -> Saturday (6).
+    function weekdayTo1Indexed(uint256 weekday0Indexed) internal pure returns (uint256 result) {
+        unchecked {
+            result = weekday0Indexed == 0 ? 7 : weekday0Indexed;
+        }
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/

--- a/src/utils/g/BeaconSlotLib.sol
+++ b/src/utils/g/BeaconSlotLib.sol
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+// This file is auto-generated.
+
+/*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+/*                         STRUCTS                           */
+/*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+/// @dev Comprehensive information about a beacon chain slot.
+struct SlotInfo {
+    uint256 slot;
+    uint256 epoch;
+    uint256 slotInEpoch;
+    uint256 startTime;
+    uint256 endTime;
+    bool isActive;
+    bool inAttestationWindow;
+}
+
+/// @dev Information about a beacon chain epoch.
+struct EpochInfo {
+    uint256 epoch;
+    uint256 firstSlot;
+    uint256 lastSlot;
+    uint256 startTime;
+    uint256 endTime;
+}
+
+using BeaconSlotLib for SlotInfo global;
+using BeaconSlotLib for EpochInfo global;
+
+/// @notice Library for Ethereum beacon chain slot calculations.
+/// @author Solady (https://github.com/vectorized/solady/blob/main/src/utils/g/BeaconSlotLib.sol)
+/// @dev
+/// This library provides gas-optimized functions for calculating Ethereum beacon chain
+/// slot numbers, epochs, and timing information. All functions are pure or view and
+/// designed to work with any beacon chain network by accepting genesis time as a parameter.
+library BeaconSlotLib {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                         CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Seconds per slot in the beacon chain.
+    uint256 internal constant SECONDS_PER_SLOT = 12;
+
+    /// @dev Number of slots per epoch.
+    uint256 internal constant SLOTS_PER_EPOCH = 32;
+
+    /// @dev Seconds per epoch (12 * 32).
+    uint256 internal constant SECONDS_PER_EPOCH = 384;
+
+    /// @dev Attestation deadline within a slot (4 seconds).
+    uint256 internal constant ATTESTATION_DEADLINE = 4;
+
+    // Network genesis times (Unix timestamps)
+
+    /// @dev Mainnet genesis time: December 1, 2020, 12:00:23 PM UTC.
+    uint256 internal constant MAINNET_GENESIS = 1606824023;
+
+    /// @dev Goerli testnet genesis time: March 23, 2021, 2:00:00 PM UTC.
+    uint256 internal constant GOERLI_GENESIS = 1616508000;
+
+    /// @dev Sepolia testnet genesis time: June 20, 2022, 2:00:00 PM UTC.
+    uint256 internal constant SEPOLIA_GENESIS = 1655733600;
+
+    /// @dev Holesky testnet genesis time: September 28, 2023, 12:00:00 PM UTC.
+    uint256 internal constant HOLESKY_GENESIS = 1695902400;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                          ERRORS                           */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev The slot number is invalid.
+    error InvalidSlot();
+
+    /// @dev The epoch number is invalid.
+    error InvalidEpoch();
+
+    /// @dev The genesis time is invalid.
+    error InvalidGenesisTime();
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                     CORE CALCULATIONS                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current beacon chain slot based on block timestamp.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return slot The current slot number, or 0 if before genesis.
+    function getCurrentSlot(uint256 genesisTime) internal view returns (uint256 slot) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let ts := timestamp()
+            let isAfterGenesis := gt(ts, genesisTime)
+            let secondsSince := mul(isAfterGenesis, sub(ts, genesisTime))
+            slot := div(secondsSince, SECONDS_PER_SLOT)
+        }
+    }
+
+    /// @dev Returns the slot number at a specific timestamp.
+    /// @param queryTime The timestamp to query.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return slot The slot number at the given timestamp, or 0 if before genesis.
+    function getSlotAtTime(uint256 queryTime, uint256 genesisTime) internal pure returns (uint256 slot) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            let isAfterGenesis := gt(queryTime, genesisTime)
+            let secondsSince := mul(isAfterGenesis, sub(queryTime, genesisTime))
+            slot := div(secondsSince, SECONDS_PER_SLOT)
+        }
+    }
+
+    /// @dev Returns the start timestamp of a given slot.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return startTime The timestamp when the slot starts.
+    function getSlotStartTime(uint256 slot, uint256 genesisTime) internal pure returns (uint256 startTime) {
+        unchecked {
+            startTime = genesisTime + (slot * SECONDS_PER_SLOT);
+        }
+    }
+
+    /// @dev Returns the end timestamp of a given slot.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return endTime The timestamp when the slot ends.
+    function getSlotEndTime(uint256 slot, uint256 genesisTime) internal pure returns (uint256 endTime) {
+        unchecked {
+            endTime = genesisTime + ((slot + 1) * SECONDS_PER_SLOT);
+        }
+    }
+
+    /// @dev Converts a slot number to its epoch number.
+    /// @param slot The slot number.
+    /// @return epoch The epoch number containing the slot.
+    function slotToEpoch(uint256 slot) internal pure returns (uint256 epoch) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Use bit shifting since SLOTS_PER_EPOCH = 32 = 2^5
+            epoch := shr(5, slot)
+        }
+    }
+
+    /// @dev Returns the position of a slot within its epoch (0-31).
+    /// @param slot The slot number.
+    /// @return slotInEpoch The position within the epoch.
+    function getSlotInEpoch(uint256 slot) internal pure returns (uint256 slotInEpoch) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Use bitwise AND since SLOTS_PER_EPOCH = 32, mask = 31
+            slotInEpoch := and(slot, 31)
+        }
+    }
+
+    /// @dev Returns the first slot number of a given epoch.
+    /// @param epoch The epoch number.
+    /// @return firstSlot The first slot number in the epoch.
+    function epochToFirstSlot(uint256 epoch) internal pure returns (uint256 firstSlot) {
+        /// @solidity memory-safe-assembly
+        assembly {
+            // Use bit shifting since SLOTS_PER_EPOCH = 32 = 2^5
+            firstSlot := shl(5, epoch)
+        }
+    }
+
+    /// @dev Returns the last slot number of a given epoch.
+    /// @param epoch The epoch number.
+    /// @return lastSlot The last slot number in the epoch.
+    function epochToLastSlot(uint256 epoch) internal pure returns (uint256 lastSlot) {
+        unchecked {
+            lastSlot = epochToFirstSlot(epoch) + SLOTS_PER_EPOCH - 1;
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    TIMING CALCULATIONS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the time until a slot starts (negative if already started).
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return secondsUntil Seconds until slot starts (negative if in the past).
+    function getTimeUntilSlot(uint256 slot, uint256 genesisTime) internal view returns (int256 secondsUntil) {
+        uint256 slotStartTime = getSlotStartTime(slot, genesisTime);
+        unchecked {
+            secondsUntil = int256(slotStartTime) - int256(block.timestamp);
+        }
+    }
+
+    /// @dev Checks if a slot is currently active.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return active True if the slot is currently active.
+    function isSlotActive(uint256 slot, uint256 genesisTime) internal view returns (bool active) {
+        uint256 startTime = getSlotStartTime(slot, genesisTime);
+        uint256 endTime = getSlotEndTime(slot, genesisTime);
+        active = block.timestamp >= startTime && block.timestamp < endTime;
+    }
+
+    /// @dev Checks if we're within the attestation window for a slot (0-4 seconds).
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return inWindow True if within the attestation window.
+    function isInAttestationWindow(uint256 slot, uint256 genesisTime) internal view returns (bool inWindow) {
+        uint256 startTime = getSlotStartTime(slot, genesisTime);
+        uint256 timeSinceStart = block.timestamp >= startTime ? block.timestamp - startTime : 0;
+        inWindow = timeSinceStart <= ATTESTATION_DEADLINE;
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   INFORMATION QUERIES                     */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns comprehensive information about a slot.
+    /// @param slot The slot number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return info Detailed information about the slot.
+    function getSlotInfo(uint256 slot, uint256 genesisTime) internal view returns (SlotInfo memory info) {
+        info.slot = slot;
+        info.epoch = slotToEpoch(slot);
+        info.slotInEpoch = getSlotInEpoch(slot);
+        info.startTime = getSlotStartTime(slot, genesisTime);
+        info.endTime = getSlotEndTime(slot, genesisTime);
+        info.isActive = isSlotActive(slot, genesisTime);
+        info.inAttestationWindow = info.isActive && isInAttestationWindow(slot, genesisTime);
+    }
+
+    /// @dev Returns information about an epoch.
+    /// @param epoch The epoch number.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return info Detailed information about the epoch.
+    function getEpochInfo(uint256 epoch, uint256 genesisTime) internal pure returns (EpochInfo memory info) {
+        info.epoch = epoch;
+        info.firstSlot = epochToFirstSlot(epoch);
+        info.lastSlot = epochToLastSlot(epoch);
+        info.startTime = getSlotStartTime(info.firstSlot, genesisTime);
+        info.endTime = getSlotEndTime(info.lastSlot, genesisTime);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    BATCH OPERATIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the range of slots that occur within a time period.
+    /// @param startTime The start timestamp.
+    /// @param endTime The end timestamp.
+    /// @param genesisTime The genesis timestamp for the target network.
+    /// @return startSlot The first slot in the range.
+    /// @return endSlot The last slot in the range.
+    /// @return count The number of slots in the range.
+    function getSlotsInTimeRange(uint256 startTime, uint256 endTime, uint256 genesisTime)
+        internal
+        pure
+        returns (uint256 startSlot, uint256 endSlot, uint256 count)
+    {
+        if (startTime > endTime) {
+            return (0, 0, 0);
+        }
+        
+        startSlot = getSlotAtTime(startTime, genesisTime);
+        endSlot = getSlotAtTime(endTime, genesisTime);
+        
+        // Handle case where endTime is exactly at slot boundary
+        if (endTime == getSlotStartTime(endSlot, genesisTime) && endSlot > 0) {
+            endSlot -= 1;
+        }
+        
+        count = endSlot >= startSlot ? endSlot - startSlot + 1 : 0;
+    }
+
+    /// @dev Returns the first and last slot numbers for an epoch.
+    /// @param epoch The epoch number.
+    /// @return firstSlot The first slot in the epoch.
+    /// @return lastSlot The last slot in the epoch.
+    function getEpochBounds(uint256 epoch) internal pure returns (uint256 firstSlot, uint256 lastSlot) {
+        firstSlot = epochToFirstSlot(epoch);
+        lastSlot = epochToLastSlot(epoch);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   NETWORK UTILITIES                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Returns the current slot for Ethereum mainnet.
+    /// @return slot The current mainnet slot.
+    function getCurrentMainnetSlot() internal view returns (uint256 slot) {
+        slot = getCurrentSlot(MAINNET_GENESIS);
+    }
+
+    /// @dev Returns the current slot for Sepolia testnet.
+    /// @return slot The current Sepolia slot.
+    function getCurrentSepoliaSlot() internal view returns (uint256 slot) {
+        slot = getCurrentSlot(SEPOLIA_GENESIS);
+    }
+
+    /// @dev Returns the current slot for Holesky testnet.
+    /// @return slot The current Holesky slot.
+    function getCurrentHoleskySlot() internal view returns (uint256 slot) {
+        slot = getCurrentSlot(HOLESKY_GENESIS);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    HELPER FUNCTIONS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    /// @dev Formats a slot number with epoch information.
+    /// @param slot The slot number.
+    /// @return formatted A string representation of the slot and epoch.
+    /// @dev Note: This function is provided for convenience but may be gas-expensive.
+    /// Consider using LibString.toString() directly if you need just the number.
+    function formatSlot(uint256 slot) internal pure returns (string memory formatted) {
+        // For production use, import LibString and use LibString.toString()
+        // This is a simplified implementation for demonstration
+        uint256 epoch = slotToEpoch(slot);
+        uint256 slotInEpoch = getSlotInEpoch(slot);
+        
+        formatted = string(abi.encodePacked(
+            "Slot ", _toString(slot),
+            " (Epoch ", _toString(epoch),
+            ", Slot ", _toString(slotInEpoch), "/31)"
+        ));
+    }
+
+    /// @dev Simple internal toString function.
+    /// @dev For production, use LibString.toString() instead.
+    function _toString(uint256 value) private pure returns (string memory str) {
+        if (value == 0) return "0";
+        
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        
+        str = string(buffer);
+    }
+}

--- a/test/BeaconSlotLib.t.sol
+++ b/test/BeaconSlotLib.t.sol
@@ -161,6 +161,226 @@ contract BeaconSlotLibTest is SoladyTest, BeaconNetworks {
     }
 
     /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*              COMPREHENSIVE PROPERTY TESTS                */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+    
+    // Property-based tests verify mathematical invariants that must hold for all inputs.
+    // These tests ensure correctness of assembly optimizations and edge case handling.
+    // Key invariants tested:
+    // 1. Slot/Epoch bidirectional consistency: slotToEpoch(epochToFirstSlot(E)) == E
+    // 2. Timestamp roundtrip accuracy: slot ↔ timestamp conversions preserve timing
+    // 3. Mathematical correctness: Assembly bit shifts match pure division/modulo
+    // 4. Boundary conditions: Epoch transitions and type limits behave correctly
+    // 5. Time range queries: Batch operations return consistent slot counts
+
+    /// @dev Property test for all slot/epoch mathematical invariants
+    function testSlotEpochInvariantsFuzz(uint256 slot, uint256 epoch) public {
+        // Bound inputs to reasonable ranges to avoid overflow
+        slot = _bound(slot, 0, type(uint64).max);
+        epoch = _bound(epoch, 0, type(uint32).max);
+        
+        // Test bidirectional slot/epoch consistency
+        uint256 calculatedEpoch = BeaconSlotLib.slotToEpoch(slot);
+        uint256 firstSlotOfEpoch = BeaconSlotLib.epochToFirstSlot(epoch);
+        uint256 lastSlotOfEpoch = BeaconSlotLib.epochToLastSlot(epoch);
+        
+        // Property 1: Slot to epoch calculation should match mathematical division
+        assertEq(calculatedEpoch, slot / 32, "Slot to epoch calculation incorrect");
+        
+        // Property 2: First slot of epoch should map back to the same epoch
+        assertEq(BeaconSlotLib.slotToEpoch(firstSlotOfEpoch), epoch, "First slot epoch mapping failed");
+        
+        // Property 3: Last slot of epoch should map back to the same epoch
+        assertEq(BeaconSlotLib.slotToEpoch(lastSlotOfEpoch), epoch, "Last slot epoch mapping failed");
+        
+        // Property 4: Last slot should be exactly 31 slots after first slot
+        assertEq(lastSlotOfEpoch, firstSlotOfEpoch + 31, "Epoch slot range incorrect");
+        
+        // Property 5: Slot in epoch should be in valid range [0, 31]
+        uint256 slotInEpoch = BeaconSlotLib.getSlotInEpoch(slot);
+        assertTrue(slotInEpoch < 32, "Slot in epoch out of bounds");
+        assertEq(slotInEpoch, slot % 32, "Slot in epoch calculation incorrect");
+        
+        // Property 6: Epoch boundaries should be exact
+        if (slot % 32 == 0) {
+            assertEq(slot, BeaconSlotLib.epochToFirstSlot(calculatedEpoch), "Epoch boundary misaligned");
+        }
+        if (slot % 32 == 31) {
+            assertEq(slot, BeaconSlotLib.epochToLastSlot(calculatedEpoch), "Epoch boundary misaligned");
+        }
+        
+        // Use helper for additional consistency checks
+        _assertSlotEpochConsistency(slot, calculatedEpoch);
+    }
+
+    /// @dev Property test for all timestamp/timing mathematical invariants
+    function testTimestampRoundtripPropertiesFuzz(uint256 slot, uint256 timestamp, uint256 genesisTime) public {
+        // Bound inputs to realistic ranges
+        slot = _bound(slot, 0, type(uint64).max);
+        timestamp = _bound(timestamp, 0, type(uint40).max);
+        genesisTime = _bound(genesisTime, 1, type(uint32).max);
+        
+        // Property 1: Slot duration is always exactly 12 seconds
+        uint256 startTime = BeaconSlotLib.getSlotStartTime(slot, genesisTime);
+        uint256 endTime = BeaconSlotLib.getSlotEndTime(slot, genesisTime);
+        assertEq(endTime - startTime, 12, "Slot duration not 12 seconds");
+        
+        // Property 2: Start time calculation is mathematically correct
+        assertEq(startTime, genesisTime + (slot * 12), "Start time calculation incorrect");
+        
+        // Property 3: Timestamp roundtrip consistency
+        uint256 slotFromTime = BeaconSlotLib.getSlotAtTime(timestamp, genesisTime);
+        uint256 timeFromSlot = BeaconSlotLib.getSlotStartTime(slotFromTime, genesisTime);
+        
+        if (timestamp >= genesisTime) {
+            // Forward direction: timestamp should fall within calculated slot's time range
+            assertTrue(timeFromSlot <= timestamp, "Timestamp before slot start");
+            assertTrue(timestamp < timeFromSlot + 12, "Timestamp after slot end");
+            
+            // Reverse direction: slot start time should map back to same slot
+            assertEq(BeaconSlotLib.getSlotAtTime(timeFromSlot, genesisTime), slotFromTime, "Slot roundtrip failed");
+        } else {
+            // Property 4: Pre-genesis timestamps should return slot 0
+            assertEq(slotFromTime, 0, "Pre-genesis should return slot 0");
+        }
+        
+        // Property 5: Epoch duration is always exactly 384 seconds (32 * 12)
+        uint256 epoch = BeaconSlotLib.slotToEpoch(slot);
+        uint256 epochFirstSlot = BeaconSlotLib.epochToFirstSlot(epoch);
+        uint256 epochLastSlot = BeaconSlotLib.epochToLastSlot(epoch);
+        uint256 epochStartTime = BeaconSlotLib.getSlotStartTime(epochFirstSlot, genesisTime);
+        uint256 epochEndTime = BeaconSlotLib.getSlotEndTime(epochLastSlot, genesisTime);
+        assertEq(epochEndTime - epochStartTime, 384, "Epoch duration not 384 seconds");
+        
+        // Use helper for additional timing checks
+        _assertTimingInvariants(slot, genesisTime);
+    }
+
+    /// @dev Property test for batch operations and time range queries
+    function testBatchOperationPropertiesFuzz(uint256 startTime, uint256 endTime, uint256 genesisTime) public {
+        // Bound inputs to reasonable ranges
+        startTime = _bound(startTime, 0, type(uint40).max);
+        endTime = _bound(endTime, startTime, type(uint40).max); // Ensure endTime >= startTime
+        genesisTime = _bound(genesisTime, 1, type(uint32).max);
+        
+        (uint256 startSlot, uint256 endSlot, uint256 count) = 
+            BeaconSlotLib.getSlotsInTimeRange(startTime, endTime, genesisTime);
+        
+        if (startTime <= endTime) {
+            // Property 1: Count should match slot range calculation
+            if (endSlot >= startSlot) {
+                assertEq(count, endSlot - startSlot + 1, "Time range count incorrect");
+            } else {
+                assertEq(count, 0, "Invalid range should have zero count");
+            }
+            
+            // Property 2: Start slot should contain start time
+            uint256 startSlotBeginTime = BeaconSlotLib.getSlotStartTime(startSlot, genesisTime);
+            uint256 startSlotEndTime = BeaconSlotLib.getSlotEndTime(startSlot, genesisTime);
+            if (startTime >= genesisTime) {
+                assertTrue(startSlotBeginTime <= startTime, "Start time not in start slot");
+                assertTrue(startTime < startSlotEndTime, "Start time not in start slot");
+            }
+            
+            // Property 3: End slot should contain end time (or be boundary case)
+            uint256 endSlotBeginTime = BeaconSlotLib.getSlotStartTime(endSlot, genesisTime);
+            if (endTime >= genesisTime && count > 0) {
+                assertTrue(endSlotBeginTime <= endTime, "End time not in end slot range");
+                // Note: endTime might equal endSlotBeginTime (boundary case handled by implementation)
+            }
+        }
+        
+        // Property 4: Epoch bounds should be mathematically consistent
+        uint256 testEpoch = _bound(startTime, 0, type(uint32).max); // Reuse as epoch number
+        (uint256 firstSlot, uint256 lastSlot) = BeaconSlotLib.getEpochBounds(testEpoch);
+        assertEq(firstSlot, testEpoch * 32, "Epoch first slot calculation incorrect");
+        assertEq(lastSlot, testEpoch * 32 + 31, "Epoch last slot calculation incorrect");
+        
+        // Property 5: Empty range handling
+        if (startTime > endTime) {
+            (,, uint256 emptyCount) = BeaconSlotLib.getSlotsInTimeRange(endTime, startTime, genesisTime);
+            assertEq(emptyCount, 0, "Invalid range should return zero count");
+        }
+    }
+
+    /// @dev Property test verifying assembly optimizations maintain mathematical correctness
+    function testAssemblyOptimizationVerificationFuzz(uint256 slot, uint256 epoch) public {
+        // Bound to ranges where both assembly and pure calculations work
+        slot = _bound(slot, 0, type(uint64).max);
+        epoch = _bound(epoch, 0, type(uint32).max);
+        
+        // Property 1: Assembly bit shift for slotToEpoch should match division
+        uint256 assemblyResult = BeaconSlotLib.slotToEpoch(slot);
+        uint256 mathResult = slot / 32;
+        assertEq(assemblyResult, mathResult, "Assembly slotToEpoch doesn't match division");
+        
+        // Property 2: Assembly bit mask for getSlotInEpoch should match modulo
+        uint256 assemblySlotInEpoch = BeaconSlotLib.getSlotInEpoch(slot);
+        uint256 mathSlotInEpoch = slot % 32;
+        assertEq(assemblySlotInEpoch, mathSlotInEpoch, "Assembly getSlotInEpoch doesn't match modulo");
+        
+        // Property 3: Assembly bit shift for epochToFirstSlot should match multiplication
+        uint256 assemblyFirstSlot = BeaconSlotLib.epochToFirstSlot(epoch);
+        uint256 mathFirstSlot = epoch * 32;
+        assertEq(assemblyFirstSlot, mathFirstSlot, "Assembly epochToFirstSlot doesn't match multiplication");
+        
+        // Property 4: Test critical boundary conditions at powers of 2
+        uint256[] memory boundarySlots = new uint256[](6);
+        boundarySlots[0] = 31;   // Last slot of epoch 0
+        boundarySlots[1] = 32;   // First slot of epoch 1  
+        boundarySlots[2] = 63;   // Last slot of epoch 1
+        boundarySlots[3] = 64;   // First slot of epoch 2
+        boundarySlots[4] = 1023; // Last slot of epoch 31
+        boundarySlots[5] = 1024; // First slot of epoch 32
+        
+        for (uint256 i = 0; i < boundarySlots.length; i++) {
+            uint256 boundarySlot = boundarySlots[i];
+            uint256 boundaryEpoch = BeaconSlotLib.slotToEpoch(boundarySlot);
+            uint256 expectedEpoch = boundarySlot / 32;
+            assertEq(boundaryEpoch, expectedEpoch, "Boundary slot epoch calculation failed");
+            
+            uint256 slotInEpoch = BeaconSlotLib.getSlotInEpoch(boundarySlot);
+            uint256 expectedSlotInEpoch = boundarySlot % 32;
+            assertEq(slotInEpoch, expectedSlotInEpoch, "Boundary slot-in-epoch calculation failed");
+        }
+        
+        // Property 5: Assembly should handle edge cases same as pure math
+        if (slot < type(uint64).max - 32) { // Avoid overflow
+            uint256 nextEpochFirstSlot = BeaconSlotLib.epochToFirstSlot(assemblyResult + 1);
+            assertTrue(nextEpochFirstSlot > slot, "Next epoch should start after current slot");
+            assertTrue(nextEpochFirstSlot <= slot + 32, "Next epoch should start within 32 slots");
+        }
+    }
+
+    /// @dev Helper function to assert slot/epoch consistency properties
+    function _assertSlotEpochConsistency(uint256 slot, uint256 epoch) internal {
+        // Verify epoch contains the slot
+        uint256 epochFirstSlot = BeaconSlotLib.epochToFirstSlot(epoch);
+        uint256 epochLastSlot = BeaconSlotLib.epochToLastSlot(epoch);
+        assertTrue(slot >= epochFirstSlot && slot <= epochLastSlot, "Slot not in calculated epoch range");
+        
+        // Verify slot position within epoch
+        uint256 slotInEpoch = BeaconSlotLib.getSlotInEpoch(slot);
+        assertEq(slot, epochFirstSlot + slotInEpoch, "Slot position calculation inconsistent");
+    }
+
+    /// @dev Helper function to assert timing invariant properties
+    function _assertTimingInvariants(uint256 slot, uint256 genesisTime) internal {
+        uint256 startTime = BeaconSlotLib.getSlotStartTime(slot, genesisTime);
+        uint256 endTime = BeaconSlotLib.getSlotEndTime(slot, genesisTime);
+        
+        // Timing must be sequential and non-overlapping
+        assertTrue(startTime < endTime, "Slot start must be before end");
+        assertEq(endTime - startTime, 12, "Slot duration must be exactly 12 seconds");
+        
+        // Next slot should start exactly when current slot ends
+        if (slot < type(uint64).max) { // Avoid overflow
+            uint256 nextSlotStart = BeaconSlotLib.getSlotStartTime(slot + 1, genesisTime);
+            assertEq(nextSlotStart, endTime, "Adjacent slots must be contiguous");
+        }
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
     /*                   STRUCT TESTS                            */
     /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
 

--- a/test/BeaconSlotLib.t.sol
+++ b/test/BeaconSlotLib.t.sol
@@ -1,0 +1,362 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./utils/SoladyTest.sol";
+import {BeaconSlotLib} from "../src/utils/BeaconSlotLib.sol";
+import {BeaconNetworks} from "../src/utils/BeaconNetworks.sol";
+
+contract BeaconSlotLibTest is SoladyTest, BeaconNetworks {
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                        CONSTANTS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    // Known slot numbers for testing
+    uint256 constant TEST_SLOT_0 = 0;
+    uint256 constant TEST_SLOT_100 = 100;
+    uint256 constant TEST_SLOT_1000 = 1000;
+    uint256 constant TEST_SLOT_EPOCH_BOUNDARY = 32; // First slot of epoch 1
+
+    // Test timestamps
+    uint256 constant MAINNET_GENESIS = BeaconSlotLib.MAINNET_GENESIS;
+    uint256 constant AFTER_GENESIS = MAINNET_GENESIS + 120; // 10 slots after genesis
+    uint256 constant BEFORE_GENESIS = MAINNET_GENESIS - 60;
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                    BASIC MATH TESTS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testSlotToEpoch() public {
+        // Test epoch boundaries
+        assertEq(BeaconSlotLib.slotToEpoch(0), 0);
+        assertEq(BeaconSlotLib.slotToEpoch(31), 0);
+        assertEq(BeaconSlotLib.slotToEpoch(32), 1);
+        assertEq(BeaconSlotLib.slotToEpoch(63), 1);
+        assertEq(BeaconSlotLib.slotToEpoch(64), 2);
+        
+        // Test larger numbers
+        assertEq(BeaconSlotLib.slotToEpoch(1000), 31); // 1000 / 32 = 31.25, floored = 31
+        assertEq(BeaconSlotLib.slotToEpoch(1024), 32); // 1024 / 32 = 32
+    }
+
+    function testGetSlotInEpoch() public {
+        // Test within first epoch
+        assertEq(BeaconSlotLib.getSlotInEpoch(0), 0);
+        assertEq(BeaconSlotLib.getSlotInEpoch(15), 15);
+        assertEq(BeaconSlotLib.getSlotInEpoch(31), 31);
+        
+        // Test epoch boundaries
+        assertEq(BeaconSlotLib.getSlotInEpoch(32), 0);
+        assertEq(BeaconSlotLib.getSlotInEpoch(63), 31);
+        assertEq(BeaconSlotLib.getSlotInEpoch(64), 0);
+    }
+
+    function testEpochToFirstSlot() public {
+        assertEq(BeaconSlotLib.epochToFirstSlot(0), 0);
+        assertEq(BeaconSlotLib.epochToFirstSlot(1), 32);
+        assertEq(BeaconSlotLib.epochToFirstSlot(2), 64);
+        assertEq(BeaconSlotLib.epochToFirstSlot(100), 3200);
+    }
+
+    function testEpochToLastSlot() public {
+        assertEq(BeaconSlotLib.epochToLastSlot(0), 31);
+        assertEq(BeaconSlotLib.epochToLastSlot(1), 63);
+        assertEq(BeaconSlotLib.epochToLastSlot(2), 95);
+        assertEq(BeaconSlotLib.epochToLastSlot(100), 3231);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   TIMESTAMP TESTS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testGetSlotStartTime() public {
+        uint256 genesis = MAINNET_GENESIS;
+        
+        assertEq(BeaconSlotLib.getSlotStartTime(0, genesis), genesis);
+        assertEq(BeaconSlotLib.getSlotStartTime(1, genesis), genesis + 12);
+        assertEq(BeaconSlotLib.getSlotStartTime(100, genesis), genesis + 1200);
+    }
+
+    function testGetSlotEndTime() public {
+        uint256 genesis = MAINNET_GENESIS;
+        
+        assertEq(BeaconSlotLib.getSlotEndTime(0, genesis), genesis + 12);
+        assertEq(BeaconSlotLib.getSlotEndTime(1, genesis), genesis + 24);
+        assertEq(BeaconSlotLib.getSlotEndTime(100, genesis), genesis + 1212);
+    }
+
+    function testGetSlotAtTime() public {
+        uint256 genesis = MAINNET_GENESIS;
+        
+        // Exactly at genesis
+        assertEq(BeaconSlotLib.getSlotAtTime(genesis, genesis), 0);
+        
+        // Within first slot (0-11 seconds)
+        assertEq(BeaconSlotLib.getSlotAtTime(genesis + 5, genesis), 0);
+        assertEq(BeaconSlotLib.getSlotAtTime(genesis + 11, genesis), 0);
+        
+        // Exactly at slot 1 start
+        assertEq(BeaconSlotLib.getSlotAtTime(genesis + 12, genesis), 1);
+        
+        // Before genesis
+        assertEq(BeaconSlotLib.getSlotAtTime(genesis - 1, genesis), 0);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   FUZZ TESTS                              */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testSlotToEpochFuzz(uint256 slot) public {
+        // Bound slot to reasonable range to avoid overflow
+        slot = _bound(slot, 0, type(uint128).max);
+        
+        uint256 epoch = BeaconSlotLib.slotToEpoch(slot);
+        uint256 expectedEpoch = slot / 32;
+        
+        assertEq(epoch, expectedEpoch);
+    }
+
+    function testGetSlotInEpochFuzz(uint256 slot) public {
+        slot = _bound(slot, 0, type(uint128).max);
+        
+        uint256 slotInEpoch = BeaconSlotLib.getSlotInEpoch(slot);
+        uint256 expectedSlotInEpoch = slot % 32;
+        
+        assertEq(slotInEpoch, expectedSlotInEpoch);
+        assertTrue(slotInEpoch < 32);
+    }
+
+    function testEpochSlotConsistencyFuzz(uint256 epoch) public {
+        epoch = _bound(epoch, 0, type(uint64).max);
+        
+        uint256 firstSlot = BeaconSlotLib.epochToFirstSlot(epoch);
+        uint256 lastSlot = BeaconSlotLib.epochToLastSlot(epoch);
+        
+        // First slot should map back to the epoch
+        assertEq(BeaconSlotLib.slotToEpoch(firstSlot), epoch);
+        assertEq(BeaconSlotLib.slotToEpoch(lastSlot), epoch);
+        
+        // Last slot should be 31 more than first slot
+        assertEq(lastSlot, firstSlot + 31);
+        
+        // Slot in epoch should be correct
+        assertEq(BeaconSlotLib.getSlotInEpoch(firstSlot), 0);
+        assertEq(BeaconSlotLib.getSlotInEpoch(lastSlot), 31);
+    }
+
+    function testTimestampCalculationsFuzz(uint256 slot, uint256 genesisTime) public {
+        slot = _bound(slot, 0, type(uint64).max);
+        genesisTime = _bound(genesisTime, 1, type(uint32).max);
+        
+        uint256 startTime = BeaconSlotLib.getSlotStartTime(slot, genesisTime);
+        uint256 endTime = BeaconSlotLib.getSlotEndTime(slot, genesisTime);
+        
+        // End time should be 12 seconds after start time
+        assertEq(endTime - startTime, 12);
+        
+        // Start time should be calculable from slot
+        assertEq(startTime, genesisTime + (slot * 12));
+        
+        // Should be able to get slot back from start time
+        assertEq(BeaconSlotLib.getSlotAtTime(startTime, genesisTime), slot);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   STRUCT TESTS                            */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testGetSlotInfo() public {
+        uint256 slot = 100;
+        uint256 genesis = MAINNET_GENESIS;
+        
+        BeaconSlotLib.SlotInfo memory info = BeaconSlotLib.getSlotInfo(slot, genesis);
+        
+        assertEq(info.slot, slot);
+        assertEq(info.epoch, BeaconSlotLib.slotToEpoch(slot));
+        assertEq(info.slotInEpoch, BeaconSlotLib.getSlotInEpoch(slot));
+        assertEq(info.startTime, BeaconSlotLib.getSlotStartTime(slot, genesis));
+        assertEq(info.endTime, BeaconSlotLib.getSlotEndTime(slot, genesis));
+    }
+
+    function testGetEpochInfo() public {
+        uint256 epoch = 10;
+        uint256 genesis = MAINNET_GENESIS;
+        
+        BeaconSlotLib.EpochInfo memory info = BeaconSlotLib.getEpochInfo(epoch, genesis);
+        
+        assertEq(info.epoch, epoch);
+        assertEq(info.firstSlot, BeaconSlotLib.epochToFirstSlot(epoch));
+        assertEq(info.lastSlot, BeaconSlotLib.epochToLastSlot(epoch));
+        assertEq(info.startTime, BeaconSlotLib.getSlotStartTime(info.firstSlot, genesis));
+        assertEq(info.endTime, BeaconSlotLib.getSlotEndTime(info.lastSlot, genesis));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   BATCH OPERATION TESTS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testGetSlotsInTimeRange() public {
+        uint256 genesis = MAINNET_GENESIS;
+        uint256 startTime = genesis + 24; // Start of slot 2
+        uint256 endTime = genesis + 66; // Middle of slot 5 (slot 5 starts at genesis + 60)
+        
+        (uint256 startSlot, uint256 endSlot, uint256 count) = 
+            BeaconSlotLib.getSlotsInTimeRange(startTime, endTime, genesis);
+        
+        assertEq(startSlot, 2);
+        assertEq(endSlot, 5);
+        assertEq(count, 4); // Slots 2, 3, 4, 5
+    }
+
+    function testGetSlotsInTimeRangeEdgeCases() public {
+        uint256 genesis = MAINNET_GENESIS;
+        
+        // Empty range (start > end)
+        (uint256 startSlot, uint256 endSlot, uint256 count) = 
+            BeaconSlotLib.getSlotsInTimeRange(genesis + 100, genesis + 50, genesis);
+        assertEq(count, 0);
+        
+        // Single slot
+        (startSlot, endSlot, count) = 
+            BeaconSlotLib.getSlotsInTimeRange(genesis, genesis + 5, genesis);
+        assertEq(startSlot, 0);
+        assertEq(endSlot, 0);
+        assertEq(count, 1);
+    }
+
+    function testGetEpochBounds() public {
+        (uint256 firstSlot, uint256 lastSlot) = BeaconSlotLib.getEpochBounds(5);
+        
+        assertEq(firstSlot, 160); // 5 * 32
+        assertEq(lastSlot, 191); // 5 * 32 + 31
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   NETWORK HELPER TESTS                    */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testNetworkConstants() public {
+        // Verify the genesis times are what we expect
+        assertEq(BeaconSlotLib.MAINNET_GENESIS, 1606824023);
+        assertEq(BeaconSlotLib.SEPOLIA_GENESIS, 1655733600);
+        assertEq(BeaconSlotLib.HOLESKY_GENESIS, 1695902400);
+    }
+
+    function testNetworkHelperFunctions() public {
+        // Test that the helper functions work
+        uint256 mainnetSlot = BeaconSlotLib.getCurrentMainnetSlot();
+        uint256 sepoliaSlot = BeaconSlotLib.getCurrentSepoliaSlot();
+        uint256 holeskySlot = BeaconSlotLib.getCurrentHoleskySlot();
+        
+        // In test environment, block.timestamp might be 1, so these could be 0
+        // Just test that they return consistent values with the manual calculation
+        assertEq(mainnetSlot, BeaconSlotLib.getCurrentSlot(BeaconSlotLib.MAINNET_GENESIS));
+        assertEq(sepoliaSlot, BeaconSlotLib.getCurrentSlot(BeaconSlotLib.SEPOLIA_GENESIS));
+        assertEq(holeskySlot, BeaconSlotLib.getCurrentSlot(BeaconSlotLib.HOLESKY_GENESIS));
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   BEACON NETWORKS TESTS                   */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testBeaconNetworksInheritance() public {
+        // Test that we can use the inherited functions
+        uint256 mainnetSlot = getMainnetSlot();
+        uint256 mainnetEpoch = getMainnetEpoch();
+        
+        // Test that inherited functions work consistently
+        assertEq(mainnetSlot, BeaconSlotLib.getCurrentMainnetSlot());
+        assertEq(mainnetEpoch, BeaconSlotLib.slotToEpoch(mainnetSlot));
+    }
+
+    function testBeaconNetworksEnum() public {
+        assertEq(uint256(Network.MAINNET), 0);
+        assertEq(uint256(Network.SEPOLIA), 1);
+        assertEq(uint256(Network.HOLESKY), 2);
+        
+        assertEq(getGenesisTime(Network.MAINNET), BeaconSlotLib.MAINNET_GENESIS);
+        assertEq(getGenesisTime(Network.SEPOLIA), BeaconSlotLib.SEPOLIA_GENESIS);
+        assertEq(getGenesisTime(Network.HOLESKY), BeaconSlotLib.HOLESKY_GENESIS);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   GAS BENCHMARKS                          */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testGetCurrentSlotGas() public {
+        uint256 gasBefore = gasleft();
+        BeaconSlotLib.getCurrentSlot(MAINNET_GENESIS);
+        uint256 gasUsed = gasBefore - gasleft();
+        
+        // Should be very gas efficient
+        assertTrue(gasUsed < 1000);
+    }
+
+    function testSlotToEpochGas() public {
+        uint256 gasBefore = gasleft();
+        BeaconSlotLib.slotToEpoch(1000000);
+        uint256 gasUsed = gasBefore - gasleft();
+        
+        // Should be extremely efficient (just a bit shift)
+        assertTrue(gasUsed < 500);
+    }
+
+    function testGetSlotInfoGas() public {
+        uint256 gasBefore = gasleft();
+        BeaconSlotLib.getSlotInfo(1000, MAINNET_GENESIS);
+        uint256 gasUsed = gasBefore - gasleft();
+        
+        // Should be reasonably efficient even for complex struct
+        assertTrue(gasUsed < 5000);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   EDGE CASE TESTS                         */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testPreGenesisHandling() public {
+        uint256 genesis = MAINNET_GENESIS;
+        
+        // Before genesis should return 0
+        assertEq(BeaconSlotLib.getSlotAtTime(genesis - 1, genesis), 0);
+        assertEq(BeaconSlotLib.getSlotAtTime(0, genesis), 0);
+    }
+
+    function testLargeNumbers() public {
+        // Test with large but reasonable slot numbers
+        uint256 largeSlot = 10000000; // About 3.8 years of slots
+        uint256 epoch = BeaconSlotLib.slotToEpoch(largeSlot);
+        uint256 slotInEpoch = BeaconSlotLib.getSlotInEpoch(largeSlot);
+        
+        assertEq(epoch, largeSlot / 32);
+        assertEq(slotInEpoch, largeSlot % 32);
+        assertTrue(slotInEpoch < 32);
+    }
+
+    function testFormatSlot() public {
+        string memory formatted = BeaconSlotLib.formatSlot(100);
+        
+        // Should contain expected components
+        // Note: This is a basic test since string comparison is complex in Solidity
+        assertTrue(bytes(formatted).length > 0);
+    }
+
+    /*´:°•.°+.*•´.*:˚.°*.˚•´.°:°•.°•.*•´.*:˚.°*.˚•´.°:°•.°+.*•´.*:*/
+    /*                   INTEGRATION TESTS                       */
+    /*.•°:°.´+˚.*°.˚:*.´•*.+°.•°:´*.´•*.•°.•°:°.´:•˚°.*°.˚:*.´+°.•*/
+
+    function testRealWorldScenarios() public {
+        // Test scenarios that would be used in real applications
+        uint256 currentSlot = BeaconSlotLib.getCurrentSlot(MAINNET_GENESIS);
+        
+        // Get current epoch
+        uint256 currentEpoch = BeaconSlotLib.slotToEpoch(currentSlot);
+        
+        // Get next epoch's first slot
+        uint256 nextEpochFirstSlot = BeaconSlotLib.epochToFirstSlot(currentEpoch + 1);
+        
+        // Verify relationships
+        assertTrue(nextEpochFirstSlot > currentSlot);
+        assertEq(BeaconSlotLib.slotToEpoch(nextEpochFirstSlot), currentEpoch + 1);
+        assertEq(BeaconSlotLib.getSlotInEpoch(nextEpochFirstSlot), 0);
+    }
+}


### PR DESCRIPTION
# 0-Indexed Weekday Implementation 

## Summary

adds 0-indexed weekday support by adding new variants with a "0" suffix.

## `WEEKDAY_0` Details

### New Constants (Lines 37-43)
```solidity
uint256 internal constant SUN_0 = 0;
uint256 internal constant MON_0 = 1;
uint256 internal constant TUE_0 = 2;
uint256 internal constant WED_0 = 3;
uint256 internal constant THU_0 = 4;
uint256 internal constant FRI_0 = 5;
uint256 internal constant SAT_0 = 6;
```

###  `weekday0()` (Lines 210-215)
```solidity
function weekday0(uint256 timestamp) internal pure returns (uint256 result) {
    unchecked {
        // Jan 1, 1970 was Thursday (4 in 0-indexed where Sunday=0)
        result = (timestamp / 86400 + 4) % 7;
    }
}
```

> [!WARNING]
> the difference from the 1-indexed version

- Uses offset of 4 instead of 3 (since Thursday = 4 in 0-indexed)
- No `+ 1` at the end (returns 0-6 instead of 1-7)

### Conversion Functions (Lines 354-368)

**1-indexed to 0-indexed:**
```solidity
function weekdayTo0Indexed(uint256 weekday1) internal pure returns (uint256 result) {
    unchecked {
        result = weekday1 == 7 ? 0 : weekday1;
    }
}
```

**0-indexed to 1-indexed:**
```solidity
function weekdayTo1Indexed(uint256 weekday0Indexed) internal pure returns (uint256 result) {
    unchecked {
        result = weekday0Indexed == 0 ? 7 : weekday0Indexed;
    }
}
```

### Additional Functions

1. **isWeekEnd0()** - Checks for Saturday (6) or Sunday (0)
2. **mondayTimestamp0()** - Finds most recent Monday using 0-indexed logic
3. **nthWeekdayInMonthOfYearTimestamp0()** - Finds nth occurrence of a weekday in a month

## Mapping

| Day       | 1-indexed (ISO 8601) | 0-indexed (C-style) |
|-----------|---------------------|-------------------|
| Sunday    | 7                   | 0                 |
| Monday    | 1                   | 1                 |
| Tuesday   | 2                   | 2                 |
| Wednesday | 3                   | 3                 |
| Thursday  | 4                   | 4                 |
| Friday    | 5                   | 5                 |
| Saturday  | 6                   | 6                 |
 

## Usage Example

```solidity
// Get weekday in 0-indexed format
uint256 wd0 = DateTimeLib.weekday0(timestamp); // 0-6

// Convert between systems
uint256 wd1 = DateTimeLib.weekday(timestamp);  // 1-7
uint256 converted = DateTimeLib.weekdayTo0Indexed(wd1); // Same as wd0

// Check if weekend (0-indexed)
bool isWeekend = DateTimeLib.isWeekEnd0(timestamp);
```
 